### PR TITLE
Required fields messages were not translated when switching language

### DIFF
--- a/src/components/personalInfo.jsx
+++ b/src/components/personalInfo.jsx
@@ -69,7 +69,7 @@ const PersonalInfo = ({ next, onSave }) => {
 
     requiredFields.forEach((field) => {
       if (!formData[field]) {
-        newErrors[field] = t('fieldRequired');
+        newErrors[field] = 'fieldRequired';
       }
     });
 
@@ -111,7 +111,7 @@ const PersonalInfo = ({ next, onSave }) => {
           t={t}
         />
         {errors[key] && (
-          <span className="text-red-500 text-sm">{errors[key]}</span>
+          <span className="text-red-500 text-sm">{t(errors[key])}</span>
         )}
       </div>
     );


### PR DESCRIPTION
Issue:
Required field messages once they were shown if you switch language it didn't change. 

Instead of saving the translated message we save the key and we translate it on the render.

----------------------------

- fix(personalInfo): required fields were not translated when switching language
